### PR TITLE
chore: EC2 사양 및 레플리카 수 조정 (#34)

### DIFF
--- a/k8s/deployment-app.yaml
+++ b/k8s/deployment-app.yaml
@@ -4,7 +4,8 @@ metadata:
   name: jbnu-pms-app
   namespace: jbnu-pms
 spec:
-  replicas: 2
+  # replicas: 2 (개발단계에서 t3.small로 사양 조절)
+  replicas: 1
   selector:
     matchLabels:
       app: jbnu-pms-app
@@ -42,8 +43,10 @@ spec:
             periodSeconds: 5
           resources:
             requests:
-              memory: "512Mi"
+              # memory: "512Mi" (개발단계에서 t3.small로 사양 조절)
+              memory: "256Mi"
               cpu: "250m"
             limits:
-              memory: "1Gi"
+              # memory: "1Gi" (개발단계에서 t3.small로 사양 조절)
+              memory: "768Mi"
               cpu: "500m"


### PR DESCRIPTION
- 개발 단계에서 t3.small로 다운그레이드
- replicas: 2 -> 1
- memory request: 512Mi -> 256Mi
- memory limit: 1Gi -> 768Mi (t3.small 2GB 기준)