### PR TITLE
chore: k8s probe 딜레이 조정 (#34)

### DIFF
--- a/k8s/deployment-app.yaml
+++ b/k8s/deployment-app.yaml
@@ -33,13 +33,15 @@ spec:
             httpGet:
               path: /actuator/health
               port: 8080
-            initialDelaySeconds: 60
+            # initialDelaySeconds: 60 (t3.small 다운그레이드 대응)
+            initialDelaySeconds: 120
             periodSeconds: 10
           readinessProbe:
             httpGet:
               path: /actuator/health
               port: 8080
-            initialDelaySeconds: 30
+            # initialDelaySeconds: 30 (t3.small 다운그레이드 대응)
+            initialDelaySeconds: 100
             periodSeconds: 5
           resources:
             requests:


### PR DESCRIPTION
- (livenessProbe) initialDelaySeconds: 60 -> 120
- (readinessProbe) initialDelaySeconds: 30 -> 100